### PR TITLE
Add files via upload

### DIFF
--- a/FileUploadBase.java
+++ b/FileUploadBase.java
@@ -1,0 +1,1491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.fileupload;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.fileupload.MultipartStream.ItemInputStream;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload.servlet.ServletRequestContext;
+import org.apache.commons.fileupload.util.Closeable;
+import org.apache.commons.fileupload.util.FileItemHeadersImpl;
+import org.apache.commons.fileupload.util.LimitedInputStream;
+import org.apache.commons.fileupload.util.Streams;
+
+/**
+ * <p>High level API for processing file uploads.</p>
+ *
+ * <p>This class handles multiple files per single HTML widget, sent using
+ * <code>multipart/mixed</code> encoding type, as specified by
+ * <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>.  Use {@link
+ * #parseRequest(RequestContext)} to acquire a list of {@link
+ * org.apache.commons.fileupload.FileItem}s associated with a given HTML
+ * widget.</p>
+ *
+ * <p>How the data for individual parts is stored is determined by the factory
+ * used to create them; a given part may be in memory, on disk, or somewhere
+ * else.</p>
+ *
+ * @version $Id: FileUploadBase.java 1743630 2016-05-13 09:20:45Z jochen $
+ */
+public abstract class FileUploadBase {
+
+    // ---------------------------------------------------------- Class methods
+
+    /**
+     * <p>Utility method that determines whether the request contains multipart
+     * content.</p>
+     *
+     * <p><strong>NOTE:</strong>This method will be moved to the
+     * <code>ServletFileUpload</code> class after the FileUpload 1.1 release.
+     * Unfortunately, since this method is static, it is not possible to
+     * provide its replacement until this method is removed.</p>
+     *
+     * @param ctx The request context to be evaluated. Must be non-null.
+     *
+     * @return <code>true</code> if the request is multipart;
+     *         <code>false</code> otherwise.
+     */
+    public static final boolean isMultipartContent(RequestContext ctx) {
+        String contentType = ctx.getContentType();
+        if (contentType == null) {
+            return false;
+        }
+        if (contentType.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Utility method that determines whether the request contains multipart
+     * content.
+     *
+     * @param req The servlet request to be evaluated. Must be non-null.
+     *
+     * @return <code>true</code> if the request is multipart;
+     *         <code>false</code> otherwise.
+     *
+     * @deprecated 1.1 Use the method on <code>ServletFileUpload</code> instead.
+     */
+    @Deprecated
+    public static boolean isMultipartContent(HttpServletRequest req) {
+        return ServletFileUpload.isMultipartContent(req);
+    }
+
+    // ----------------------------------------------------- Manifest constants
+
+    /**
+     * HTTP content type header name.
+     */
+    public static final String CONTENT_TYPE = "Content-type";
+
+    /**
+     * HTTP content disposition header name.
+     */
+    public static final String CONTENT_DISPOSITION = "Content-disposition";
+
+    /**
+     * HTTP content length header name.
+     */
+    public static final String CONTENT_LENGTH = "Content-length";
+
+    /**
+     * Content-disposition value for form data.
+     */
+    public static final String FORM_DATA = "form-data";
+
+    /**
+     * Content-disposition value for file attachment.
+     */
+    public static final String ATTACHMENT = "attachment";
+
+    /**
+     * Part of HTTP content type header.
+     */
+    public static final String MULTIPART = "multipart/";
+
+    /**
+     * HTTP content type header for multipart forms.
+     */
+    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+
+    /**
+     * HTTP content type header for multiple uploads.
+     */
+    public static final String MULTIPART_MIXED = "multipart/mixed";
+
+    /**
+     * The maximum length of a single header line that will be parsed
+     * (1024 bytes).
+     * @deprecated This constant is no longer used. As of commons-fileupload
+     *   1.2, the only applicable limit is the total size of a parts headers,
+     *   {@link MultipartStream#HEADER_PART_SIZE_MAX}.
+     */
+    @Deprecated
+    public static final int MAX_HEADER_SIZE = 1024;
+
+    // ----------------------------------------------------------- Data members
+
+    /**
+     * The maximum size permitted for the complete request, as opposed to
+     * {@link #fileSizeMax}. A value of -1 indicates no maximum.
+     */
+    private long sizeMax = -1;
+
+    /**
+     * The maximum size permitted for a single uploaded file, as opposed
+     * to {@link #sizeMax}. A value of -1 indicates no maximum.
+     */
+    private long fileSizeMax = -1;
+
+    /**
+     * The content encoding to use when reading part headers.
+     */
+    private String headerEncoding;
+
+    /**
+     * The progress listener.
+     */
+    private ProgressListener listener;
+
+    // ----------------------------------------------------- Property accessors
+
+    /**
+     * Returns the factory class used when creating file items.
+     *
+     * @return The factory class for new file items.
+     */
+    public abstract FileItemFactory getFileItemFactory();
+
+    /**
+     * Sets the factory class to use when creating file items.
+     *
+     * @param factory The factory class for new file items.
+     */
+    public abstract void setFileItemFactory(FileItemFactory factory);
+
+    /**
+     * Returns the maximum allowed size of a complete request, as opposed
+     * to {@link #getFileSizeMax()}.
+     *
+     * @return The maximum allowed size, in bytes. The default value of
+     *   -1 indicates, that there is no limit.
+     *
+     * @see #setSizeMax(long)
+     *
+     */
+    public long getSizeMax() {
+        return sizeMax;
+    }
+
+    /**
+     * Sets the maximum allowed size of a complete request, as opposed
+     * to {@link #setFileSizeMax(long)}.
+     *
+     * @param sizeMax The maximum allowed size, in bytes. The default value of
+     *   -1 indicates, that there is no limit.
+     *
+     * @see #getSizeMax()
+     *
+     */
+    public void setSizeMax(long sizeMax) {
+        this.sizeMax = sizeMax;
+    }
+
+    /**
+     * Returns the maximum allowed size of a single uploaded file,
+     * as opposed to {@link #getSizeMax()}.
+     *
+     * @see #setFileSizeMax(long)
+     * @return Maximum size of a single uploaded file.
+     */
+    public long getFileSizeMax() {
+        return fileSizeMax;
+    }
+
+    /**
+     * Sets the maximum allowed size of a single uploaded file,
+     * as opposed to {@link #getSizeMax()}.
+     *
+     * @see #getFileSizeMax()
+     * @param fileSizeMax Maximum size of a single uploaded file.
+     */
+    public void setFileSizeMax(long fileSizeMax) {
+        this.fileSizeMax = fileSizeMax;
+    }
+
+    /**
+     * Retrieves the character encoding used when reading the headers of an
+     * individual part. When not specified, or <code>null</code>, the request
+     * encoding is used. If that is also not specified, or <code>null</code>,
+     * the platform default encoding is used.
+     *
+     * @return The encoding used to read part headers.
+     */
+    public String getHeaderEncoding() {
+        return headerEncoding;
+    }
+
+    /**
+     * Specifies the character encoding to be used when reading the headers of
+     * individual part. When not specified, or <code>null</code>, the request
+     * encoding is used. If that is also not specified, or <code>null</code>,
+     * the platform default encoding is used.
+     *
+     * @param encoding The encoding used to read part headers.
+     */
+    public void setHeaderEncoding(String encoding) {
+        headerEncoding = encoding;
+    }
+
+    // --------------------------------------------------------- Public methods
+
+    /**
+     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+     * compliant <code>multipart/form-data</code> stream.
+     *
+     * @param req The servlet request to be parsed.
+     *
+     * @return A list of <code>FileItem</code> instances parsed from the
+     *         request, in the order that they were transmitted.
+     *
+     * @throws FileUploadException if there are problems reading/parsing
+     *                             the request or storing files.
+     *
+     * @deprecated 1.1 Use {@link ServletFileUpload#parseRequest(HttpServletRequest)} instead.
+     */
+    @Deprecated
+    public List<FileItem> parseRequest(HttpServletRequest req)
+    throws FileUploadException {
+        return parseRequest(new ServletRequestContext(req));
+    }
+
+    /**
+     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+     * compliant <code>multipart/form-data</code> stream.
+     *
+     * @param ctx The context for the request to be parsed.
+     *
+     * @return An iterator to instances of <code>FileItemStream</code>
+     *         parsed from the request, in the order that they were
+     *         transmitted.
+     *
+     * @throws FileUploadException if there are problems reading/parsing
+     *                             the request or storing files.
+     * @throws IOException An I/O error occurred. This may be a network
+     *   error while communicating with the client or a problem while
+     *   storing the uploaded content.
+     */
+    public FileItemIterator getItemIterator(RequestContext ctx)
+    throws FileUploadException, IOException {
+        try {
+            return new FileItemIteratorImpl(ctx);
+        } catch (FileUploadIOException e) {
+            // unwrap encapsulated SizeException
+            throw (FileUploadException) e.getCause();
+        }
+    }
+
+    /**
+     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+     * compliant <code>multipart/form-data</code> stream.
+     *
+     * @param ctx The context for the request to be parsed.
+     *
+     * @return A list of <code>FileItem</code> instances parsed from the
+     *         request, in the order that they were transmitted.
+     *
+     * @throws FileUploadException if there are problems reading/parsing
+     *                             the request or storing files.
+     */
+    public List<FileItem> parseRequest(RequestContext ctx)
+            throws FileUploadException {
+        List<FileItem> items = new ArrayList<FileItem>();
+        boolean successful = false;
+        try {
+            FileItemIterator iter = getItemIterator(ctx);
+            FileItemFactory fac = getFileItemFactory();
+            if (fac == null) {
+                throw new NullPointerException("No FileItemFactory has been set.");
+            }
+            while (iter.hasNext()) {
+                final FileItemStream item = iter.next();
+                // Don't use getName() here to prevent an InvalidFileNameException.
+                final String fileName = ((FileItemIteratorImpl.FileItemStreamImpl) item).name;
+                FileItem fileItem = fac.createItem(item.getFieldName(), item.getContentType(),
+                                                   item.isFormField(), fileName);
+                items.add(fileItem);
+                try {
+                    Streams.copy(item.openStream(), fileItem.getOutputStream(), true);
+                } catch (FileUploadIOException e) {
+                    throw (FileUploadException) e.getCause();
+                } catch (IOException e) {
+                    throw new IOFileUploadException(format("Processing of %s request failed. %s",
+                                                           MULTIPART_FORM_DATA, e.getMessage()), e);
+                }
+                final FileItemHeaders fih = item.getHeaders();
+                fileItem.setHeaders(fih);
+            }
+            successful = true;
+            return items;
+        } catch (FileUploadIOException e) {
+            throw (FileUploadException) e.getCause();
+        } catch (IOException e) {
+            throw new FileUploadException(e.getMessage(), e);
+        } finally {
+            if (!successful) {
+                for (FileItem fileItem : items) {
+                    try {
+                        fileItem.delete();
+                    } catch (Throwable e) {
+                        // ignore it
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+     * compliant <code>multipart/form-data</code> stream.
+     *
+     * @param ctx The context for the request to be parsed.
+     *
+     * @return A map of <code>FileItem</code> instances parsed from the request.
+     *
+     * @throws FileUploadException if there are problems reading/parsing
+     *                             the request or storing files.
+     *
+     * @since 1.3
+     */
+    public Map<String, List<FileItem>> parseParameterMap(RequestContext ctx)
+            throws FileUploadException {
+        final List<FileItem> items = parseRequest(ctx);
+        final Map<String, List<FileItem>> itemsMap = new HashMap<String, List<FileItem>>(items.size());
+
+        for (FileItem fileItem : items) {
+            String fieldName = fileItem.getFieldName();
+            List<FileItem> mappedItems = itemsMap.get(fieldName);
+
+            if (mappedItems == null) {
+                mappedItems = new ArrayList<FileItem>();
+                itemsMap.put(fieldName, mappedItems);
+            }
+
+            mappedItems.add(fileItem);
+        }
+
+        return itemsMap;
+    }
+
+    // ------------------------------------------------------ Protected methods
+
+    /**
+     * Retrieves the boundary from the <code>Content-type</code> header.
+     *
+     * @param contentType The value of the content type header from which to
+     *                    extract the boundary value.
+     *
+     * @return The boundary, as a byte array.
+     */
+    protected byte[] getBoundary(String contentType) {
+        ParameterParser parser = new ParameterParser();
+        parser.setLowerCaseNames(true);
+        // Parameter parser can handle null input
+        Map<String, String> params = parser.parse(contentType, new char[] {';', ','});
+        String boundaryStr = params.get("boundary");
+
+        if (boundaryStr == null) {
+            return null;
+        }
+        byte[] boundary;
+        try {
+            boundary = boundaryStr.getBytes("ISO-8859-1");
+        } catch (UnsupportedEncodingException e) {
+            boundary = boundaryStr.getBytes(); // Intentionally falls back to default charset
+        }
+        return boundary;
+    }
+
+    /**
+     * Retrieves the file name from the <code>Content-disposition</code>
+     * header.
+     *
+     * @param headers A <code>Map</code> containing the HTTP request headers.
+     *
+     * @return The file name for the current <code>encapsulation</code>.
+     * @deprecated 1.2.1 Use {@link #getFileName(FileItemHeaders)}.
+     */
+    @Deprecated
+    protected String getFileName(Map<String, String> headers) {
+        return getFileName(getHeader(headers, CONTENT_DISPOSITION));
+    }
+
+    /**
+     * Retrieves the file name from the <code>Content-disposition</code>
+     * header.
+     *
+     * @param headers The HTTP headers object.
+     *
+     * @return The file name for the current <code>encapsulation</code>.
+     */
+    protected String getFileName(FileItemHeaders headers) {
+        return getFileName(headers.getHeader(CONTENT_DISPOSITION));
+    }
+
+    /**
+     * Returns the given content-disposition headers file name.
+     * @param pContentDisposition The content-disposition headers value.
+     * @return The file name
+     */
+    private String getFileName(String pContentDisposition) {
+        String fileName = null;
+        if (pContentDisposition != null) {
+            String cdl = pContentDisposition.toLowerCase(Locale.ENGLISH);
+            if (cdl.startsWith(FORM_DATA) || cdl.startsWith(ATTACHMENT)) {
+                ParameterParser parser = new ParameterParser();
+                parser.setLowerCaseNames(true);
+                // Parameter parser can handle null input
+                Map<String, String> params = parser.parse(pContentDisposition, ';');
+                if (params.containsKey("filename")) {
+                    fileName = params.get("filename");
+                    if (fileName != null) {
+                        fileName = fileName.trim();
+                    } else {
+                        // Even if there is no value, the parameter is present,
+                        // so we return an empty file name rather than no file
+                        // name.
+                        fileName = "";
+                    }
+                }
+            }
+        }
+        return fileName;
+    }
+
+    /**
+     * Retrieves the field name from the <code>Content-disposition</code>
+     * header.
+     *
+     * @param headers A <code>Map</code> containing the HTTP request headers.
+     *
+     * @return The field name for the current <code>encapsulation</code>.
+     */
+    protected String getFieldName(FileItemHeaders headers) {
+        return getFieldName(headers.getHeader(CONTENT_DISPOSITION));
+    }
+
+    /**
+     * Returns the field name, which is given by the content-disposition
+     * header.
+     * @param pContentDisposition The content-dispositions header value.
+     * @return The field jake
+     */
+    private String getFieldName(String pContentDisposition) {
+        String fieldName = null;
+        if (pContentDisposition != null
+                && pContentDisposition.toLowerCase(Locale.ENGLISH).startsWith(FORM_DATA)) {
+            ParameterParser parser = new ParameterParser();
+            parser.setLowerCaseNames(true);
+            // Parameter parser can handle null input
+            Map<String, String> params = parser.parse(pContentDisposition, ';');
+            fieldName = params.get("name");
+            if (fieldName != null) {
+                fieldName = fieldName.trim();
+            }
+        }
+        return fieldName;
+    }
+
+    /**
+     * Retrieves the field name from the <code>Content-disposition</code>
+     * header.
+     *
+     * @param headers A <code>Map</code> containing the HTTP request headers.
+     *
+     * @return The field name for the current <code>encapsulation</code>.
+     * @deprecated 1.2.1 Use {@link #getFieldName(FileItemHeaders)}.
+     */
+    @Deprecated
+    protected String getFieldName(Map<String, String> headers) {
+        return getFieldName(getHeader(headers, CONTENT_DISPOSITION));
+    }
+
+    /**
+     * Creates a new {@link FileItem} instance.
+     *
+     * @param headers       A <code>Map</code> containing the HTTP request
+     *                      headers.
+     * @param isFormField   Whether or not this item is a form field, as
+     *                      opposed to a file.
+     *
+     * @return A newly created <code>FileItem</code> instance.
+     *
+     * @throws FileUploadException if an error occurs.
+     * @deprecated 1.2 This method is no longer used in favour of
+     *   internally created instances of {@link FileItem}.
+     */
+    @Deprecated
+    protected FileItem createItem(Map<String, String> headers,
+                                  boolean isFormField)
+        throws FileUploadException {
+        return getFileItemFactory().createItem(getFieldName(headers),
+                getHeader(headers, CONTENT_TYPE),
+                isFormField,
+                getFileName(headers));
+    }
+
+    /**
+     * <p> Parses the <code>header-part</code> and returns as key/value
+     * pairs.
+     *
+     * <p> If there are multiple headers of the same names, the name
+     * will map to a comma-separated list containing the values.
+     *
+     * @param headerPart The <code>header-part</code> of the current
+     *                   <code>encapsulation</code>.
+     *
+     * @return A <code>Map</code> containing the parsed HTTP request headers.
+     */
+    protected FileItemHeaders getParsedHeaders(String headerPart) {
+        final int len = headerPart.length();
+        FileItemHeadersImpl headers = newFileItemHeaders();
+        int start = 0;
+        for (;;) {
+            int end = parseEndOfLine(headerPart, start);
+            if (start == end) {
+                break;
+            }
+            StringBuilder header = new StringBuilder(headerPart.substring(start, end));
+            start = end + 2;
+            while (start < len) {
+                int nonWs = start;
+                while (nonWs < len) {
+                    char c = headerPart.charAt(nonWs);
+                    if ((c != ' ') && (c != '\t')) {
+                        break;
+                    }
+                    ++nonWs;
+                }
+                if (nonWs == start) {
+                    break;
+                }
+                // Continuation line found
+                end = parseEndOfLine(headerPart, nonWs);
+                header.append(" ").append(headerPart.substring(nonWs, end));
+                start = end + 2;
+            }
+            parseHeaderLine(headers, header.toString());
+        }
+        return headers;
+    }
+
+    /**
+     * Creates a new instance of {@link FileItemHeaders}.
+     * @return The new instance.
+     */
+    protected FileItemHeadersImpl newFileItemHeaders() {
+        return new FileItemHeadersImpl();
+    }
+
+    /**
+     * <p> Parses the <code>header-part</code> and returns as key/value
+     * pairs.
+     *
+     * <p> If there are multiple headers of the same names, the name
+     * will map to a comma-separated list containing the values.
+     *
+     * @param headerPart The <code>header-part</code> of the current
+     *                   <code>encapsulation</code>.
+     *
+     * @return A <code>Map</code> containing the parsed HTTP request headers.
+     * @deprecated 1.2.1 Use {@link #getParsedHeaders(String)}
+     */
+    @Deprecated
+    protected Map<String, String> parseHeaders(String headerPart) {
+        FileItemHeaders headers = getParsedHeaders(headerPart);
+        Map<String, String> result = new HashMap<String, String>();
+        for (Iterator<String> iter = headers.getHeaderNames();  iter.hasNext();) {
+            String headerName = iter.next();
+            Iterator<String> iter2 = headers.getHeaders(headerName);
+            StringBuilder headerValue = new StringBuilder(iter2.next());
+            while (iter2.hasNext()) {
+                headerValue.append(",").append(iter2.next());
+            }
+            result.put(headerName, headerValue.toString());
+        }
+        return result;
+    }
+
+    /**
+     * Skips bytes until the end of the current line.
+     * @param headerPart The headers, which are being parsed.
+     * @param end Index of the last byte, which has yet been
+     *   processed.
+     * @return Index of the \r\n sequence, which indicates
+     *   end of line.
+     */
+    private int parseEndOfLine(String headerPart, int end) {
+        int index = end;
+        for (;;) {
+            int offset = headerPart.indexOf('\r', index);
+            if ((offset == -1) || (offset + 1 >= headerPart.length())) {
+                throw new IllegalStateException(
+                    "Expected headers to be terminated by an empty line.");
+            }
+            if (headerPart.charAt(offset + 1) == '\n') {
+                return offset;
+            }
+            index = offset + 1;
+        }
+    }
+
+    /**
+     * Reads the next header line.
+     * @param headers String with all headers.
+     * @param header Map where to store the current header.
+     */
+    private void parseHeaderLine(FileItemHeadersImpl headers, String header) {
+        final int colonOffset = header.indexOf(':');
+        if (colonOffset == -1) {
+            // This header line is malformed, skip it.
+            return;
+        }
+        String headerName = header.substring(0, colonOffset).trim();
+        String headerValue =
+            header.substring(header.indexOf(':') + 1).trim();
+        headers.addHeader(headerName, headerValue);
+    }
+
+    /**
+     * Returns the header with the specified name from the supplied map. The
+     * header lookup is case-insensitive.
+     *
+     * @param headers A <code>Map</code> containing the HTTP request headers.
+     * @param name    The name of the header to return.
+     *
+     * @return The value of specified header, or a comma-separated list if
+     *         there were multiple headers of that name.
+     * @deprecated 1.2.1 Use {@link FileItemHeaders#getHeader(String)}.
+     */
+    @Deprecated
+    protected final String getHeader(Map<String, String> headers,
+            String name) {
+        return headers.get(name.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * The iterator, which is returned by
+     * {@link FileUploadBase#getItemIterator(RequestContext)}.
+     */
+    private class FileItemIteratorImpl implements FileItemIterator {
+
+        /**
+         * Default implementation of {@link FileItemStream}.
+         */
+        class FileItemStreamImpl implements FileItemStream {
+
+            /**
+             * The file items content type.
+             */
+            private final String contentType;
+
+            /**
+             * The file items field name.
+             */
+            private final String fieldName;
+
+            /**
+             * The file items file name.
+             */
+            private final String name;
+
+            /**
+             * Whether the file item is a form field.
+             */
+            private final boolean formField;
+
+            /**
+             * The file items input stream.
+             */
+            private final InputStream stream;
+
+            /**
+             * Whether the file item was already opened.
+             */
+            private boolean opened;
+
+            /**
+             * The headers, if any.
+             */
+            private FileItemHeaders headers;
+
+            /**
+             * Creates a new instance.
+             *
+             * @param pName The items file name, or null.
+             * @param pFieldName The items field name.
+             * @param pContentType The items content type, or null.
+             * @param pFormField Whether the item is a form field.
+             * @param pContentLength The items content length, if known, or -1
+             * @throws IOException Creating the file item failed.
+             */
+            FileItemStreamImpl(String pName, String pFieldName,
+                    String pContentType, boolean pFormField,
+                    long pContentLength) throws IOException {
+                name = pName;
+                fieldName = pFieldName;
+                contentType = pContentType;
+                formField = pFormField;
+                final ItemInputStream itemStream = multi.newInputStream();
+                InputStream istream = itemStream;
+                if (fileSizeMax != -1) {
+                    if (pContentLength != -1
+                            &&  pContentLength > fileSizeMax) {
+                        FileSizeLimitExceededException e =
+                            new FileSizeLimitExceededException(
+                                format("The field %s exceeds its maximum permitted size of %s bytes.",
+                                       fieldName, Long.valueOf(fileSizeMax)),
+                                pContentLength, fileSizeMax);
+                        e.setFileName(pName);
+                        e.setFieldName(pFieldName);
+                        throw new FileUploadIOException(e);
+                    }
+                    istream = new LimitedInputStream(istream, fileSizeMax) {
+                        @Override
+                        protected void raiseError(long pSizeMax, long pCount)
+                                throws IOException {
+                            itemStream.close(true);
+                            FileSizeLimitExceededException e =
+                                new FileSizeLimitExceededException(
+                                    format("The field %s exceeds its maximum permitted size of %s bytes.",
+                                           fieldName, Long.valueOf(pSizeMax)),
+                                    pCount, pSizeMax);
+                            e.setFieldName(fieldName);
+                            e.setFileName(name);
+                            throw new FileUploadIOException(e);
+                        }
+                    };
+                }
+                stream = istream;
+            }
+
+            /**
+             * Returns the items content type, or null.
+             *
+             * @return Content type, if known, or null.
+             */
+            public String getContentType() {
+                return contentType;
+            }
+
+            /**
+             * Returns the items field name.
+             *
+             * @return Field name.
+             */
+            public String getFieldName() {
+                return fieldName;
+            }
+
+            /**
+             * Returns the items file name.
+             *
+             * @return File name, if known, or null.
+             * @throws InvalidFileNameException The file name contains a NUL character,
+             *   which might be an indicator of a security attack. If you intend to
+             *   use the file name anyways, catch the exception and use
+             *   InvalidFileNameException#getName().
+             */
+            public String getName() {
+                return Streams.checkFileName(name);
+            }
+
+            /**
+             * Returns, whether this is a form field.
+             *
+             * @return True, if the item is a form field,
+             *   otherwise false.
+             */
+            public boolean isFormField() {
+                return formField;
+            }
+
+            /**
+             * Returns an input stream, which may be used to
+             * read the items contents.
+             *
+             * @return Opened input stream.
+             * @throws IOException An I/O error occurred.
+             */
+            public InputStream openStream() throws IOException {
+                if (opened) {
+                    throw new IllegalStateException(
+                            "The stream was already opened.");
+                }
+                if (((Closeable) stream).isClosed()) {
+                    throw new FileItemStream.ItemSkippedException();
+                }
+                return stream;
+            }
+
+            /**
+             * Closes the file item.
+             *
+             * @throws IOException An I/O error occurred.
+             */
+            void close() throws IOException {
+                stream.close();
+            }
+
+            /**
+             * Returns the file item headers.
+             *
+             * @return The items header object
+             */
+            public FileItemHeaders getHeaders() {
+                return headers;
+            }
+
+            /**
+             * Sets the file item headers.
+             *
+             * @param pHeaders The items header object
+             */
+            public void setHeaders(FileItemHeaders pHeaders) {
+                headers = pHeaders;
+            }
+
+        }
+
+        /**
+         * The multi part stream to process.
+         */
+        private final MultipartStream multi;
+
+        /**
+         * The notifier, which used for triggering the
+         * {@link ProgressListener}.
+         */
+        private final MultipartStream.ProgressNotifier notifier;
+
+        /**
+         * The boundary, which separates the various parts.
+         */
+        private final byte[] boundary;
+
+        /**
+         * The item, which we currently process.
+         */
+        private FileItemStreamImpl currentItem;
+
+        /**
+         * The current items field name.
+         */
+        private String currentFieldName;
+
+        /**
+         * Whether we are currently skipping the preamble.
+         */
+        private boolean skipPreamble;
+
+        /**
+         * Whether the current item may still be read.
+         */
+        private boolean itemValid;
+
+        /**
+         * Whether we have seen the end of the file.
+         */
+        private boolean eof;
+
+        /**
+         * Creates a new instance.
+         *
+         * @param ctx The request context.
+         * @throws FileUploadException An error occurred while
+         *   parsing the request.
+         * @throws IOException An I/O error occurred.
+         */
+        FileItemIteratorImpl(RequestContext ctx)
+                throws FileUploadException, IOException {
+            if (ctx == null) {
+                throw new NullPointerException("ctx parameter");
+            }
+
+            String contentType = ctx.getContentType();
+            if ((null == contentType)
+                    || (!contentType.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART))) {
+                throw new InvalidContentTypeException(
+                        format("the request doesn't contain a %s or %s stream, content type header is %s",
+                               MULTIPART_FORM_DATA, MULTIPART_MIXED, contentType));
+            }
+
+            InputStream input = ctx.getInputStream();
+
+            @SuppressWarnings("deprecation") // still has to be backward compatible
+            final int contentLengthInt = ctx.getContentLength();
+
+            final long requestSize = UploadContext.class.isAssignableFrom(ctx.getClass())
+                                     // Inline conditional is OK here CHECKSTYLE:OFF
+                                     ? ((UploadContext) ctx).contentLength()
+                                     : contentLengthInt;
+                                     // CHECKSTYLE:ON
+
+            if (sizeMax >= 0) {
+                if (requestSize != -1 && requestSize > sizeMax) {
+                    throw new SizeLimitExceededException(
+                        format("the request was rejected because its size (%s) exceeds the configured maximum (%s)",
+                                Long.valueOf(requestSize), Long.valueOf(sizeMax)),
+                               requestSize, sizeMax);
+                }
+                input = new LimitedInputStream(input, sizeMax) {
+                    @Override
+                    protected void raiseError(long pSizeMax, long pCount)
+                            throws IOException {
+                        FileUploadException ex = new SizeLimitExceededException(
+                        format("the request was rejected because its size (%s) exceeds the configured maximum (%s)",
+                                Long.valueOf(pCount), Long.valueOf(pSizeMax)),
+                               pCount, pSizeMax);
+                        throw new FileUploadIOException(ex);
+                    }
+                };
+            }
+
+            String charEncoding = headerEncoding;
+            if (charEncoding == null) {
+                charEncoding = ctx.getCharacterEncoding();
+            }
+
+            boundary = getBoundary(contentType);
+            if (boundary == null) {
+                throw new FileUploadException("the request was rejected because no multipart boundary was found");
+            }
+
+            notifier = new MultipartStream.ProgressNotifier(listener, requestSize);
+            try {
+                multi = new MultipartStream(input, boundary, notifier);
+            } catch (IllegalArgumentException iae) {
+                throw new InvalidContentTypeException(
+                        format("The boundary specified in the %s header is too long", CONTENT_TYPE), iae);
+            }
+            multi.setHeaderEncoding(charEncoding);
+
+            skipPreamble = true;
+            findNextItem();
+        }
+
+        /**
+         * Called for finding the next item, if any.
+         *
+         * @return True, if an next item was found, otherwise false.
+         * @throws IOException An I/O error occurred.
+         */
+        private boolean findNextItem() throws IOException {
+            if (eof) {
+                return false;
+            }
+            if (currentItem != null) {
+                currentItem.close();
+                currentItem = null;
+            }
+            for (;;) {
+                boolean nextPart;
+                if (skipPreamble) {
+                    nextPart = multi.skipPreamble();
+                } else {
+                    nextPart = multi.readBoundary();
+                }
+                if (!nextPart) {
+                    if (currentFieldName == null) {
+                        // Outer multipart terminated -> No more data
+                        eof = true;
+                        return false;
+                    }
+                    // Inner multipart terminated -> Return to parsing the outer
+                    multi.setBoundary(boundary);
+                    currentFieldName = null;
+                    continue;
+                }
+                FileItemHeaders headers = getParsedHeaders(multi.readHeaders());
+                if (currentFieldName == null) {
+                    // We're parsing the outer multipart
+                    String fieldName = getFieldName(headers);
+                    fieldName = fieldName == null ? "" : fieldName; // KWA Modified : Support no content-disposition bodies
+                    if (fieldName != null) {
+                        String subContentType = headers.getHeader(CONTENT_TYPE);
+                        if ((subContentType != null) && subContentType.toLowerCase().startsWith(MULTIPART_MIXED)) {
+                            currentFieldName = fieldName;
+                            // Multiple files associated with this field name
+                            byte[] subBoundary = getBoundary(subContentType);
+                            multi.setBoundary(subBoundary);
+                            skipPreamble = true;
+                            continue;
+                        }
+                        String fileName = getFileName(headers);
+                        currentItem = new FileItemStreamImpl(fileName,
+                                fieldName, headers.getHeader(CONTENT_TYPE),
+                                fileName == null, getContentLength(headers));
+                        currentItem.setHeaders(headers);
+                        notifier.noteItem();
+                        itemValid = true;
+                        return true;
+                    }
+                } else {
+                    String fileName = getFileName(headers);
+                    fileName = fileName == null ? "" : fileName; // KWA Modified : Support no content-disposition bodies
+                    if (fileName != null) {
+                        currentItem = new FileItemStreamImpl(fileName,
+                                currentFieldName,
+                                headers.getHeader(CONTENT_TYPE),
+                                false, getContentLength(headers));
+                        currentItem.setHeaders(headers);
+                        notifier.noteItem();
+                        itemValid = true;
+                        return true;
+                    }
+                }
+                multi.discardBodyData();
+            }
+        }
+
+        private long getContentLength(FileItemHeaders pHeaders) {
+            try {
+                return Long.parseLong(pHeaders.getHeader(CONTENT_LENGTH));
+            } catch (Exception e) {
+                return -1;
+            }
+        }
+
+        /**
+         * Returns, whether another instance of {@link FileItemStream}
+         * is available.
+         *
+         * @throws FileUploadException Parsing or processing the
+         *   file item failed.
+         * @throws IOException Reading the file item failed.
+         * @return True, if one or more additional file items
+         *   are available, otherwise false.
+         */
+        public boolean hasNext() throws FileUploadException, IOException {
+            if (eof) {
+                return false;
+            }
+            if (itemValid) {
+                return true;
+            }
+            try {
+                return findNextItem();
+            } catch (FileUploadIOException e) {
+                // unwrap encapsulated SizeException
+                throw (FileUploadException) e.getCause();
+            }
+        }
+
+        /**
+         * Returns the next available {@link FileItemStream}.
+         *
+         * @throws java.util.NoSuchElementException No more items are
+         *   available. Use {@link #hasNext()} to prevent this exception.
+         * @throws FileUploadException Parsing or processing the
+         *   file item failed.
+         * @throws IOException Reading the file item failed.
+         * @return FileItemStream instance, which provides
+         *   access to the next file item.
+         */
+        public FileItemStream next() throws FileUploadException, IOException {
+            if (eof  ||  (!itemValid && !hasNext())) {
+                throw new NoSuchElementException();
+            }
+            itemValid = false;
+            return currentItem;
+        }
+
+    }
+
+    /**
+     * This exception is thrown for hiding an inner
+     * {@link FileUploadException} in an {@link IOException}.
+     */
+    public static class FileUploadIOException extends IOException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = -7047616958165584154L;
+
+        /**
+         * The exceptions cause; we overwrite the parent
+         * classes field, which is available since Java
+         * 1.4 only.
+         */
+        private final FileUploadException cause;
+
+        /**
+         * Creates a <code>FileUploadIOException</code> with the
+         * given cause.
+         *
+         * @param pCause The exceptions cause, if any, or null.
+         */
+        public FileUploadIOException(FileUploadException pCause) {
+            // We're not doing super(pCause) cause of 1.3 compatibility.
+            cause = pCause;
+        }
+
+        /**
+         * Returns the exceptions cause.
+         *
+         * @return The exceptions cause, if any, or null.
+         */
+        @Override
+        public Throwable getCause() {
+            return cause;
+        }
+
+    }
+
+    /**
+     * Thrown to indicate that the request is not a multipart request.
+     */
+    public static class InvalidContentTypeException
+            extends FileUploadException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = -9073026332015646668L;
+
+        /**
+         * Constructs a <code>InvalidContentTypeException</code> with no
+         * detail message.
+         */
+        public InvalidContentTypeException() {
+            super();
+        }
+
+        /**
+         * Constructs an <code>InvalidContentTypeException</code> with
+         * the specified detail message.
+         *
+         * @param message The detail message.
+         */
+        public InvalidContentTypeException(String message) {
+            super(message);
+        }
+
+        /**
+         * Constructs an <code>InvalidContentTypeException</code> with
+         * the specified detail message and cause.
+         *
+         * @param msg The detail message.
+         * @param cause the original cause
+         *
+         * @since 1.3.1
+         */
+        public InvalidContentTypeException(String msg, Throwable cause) {
+            super(msg, cause);
+        }
+    }
+
+    /**
+     * Thrown to indicate an IOException.
+     */
+    public static class IOFileUploadException extends FileUploadException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = 1749796615868477269L;
+
+        /**
+         * The exceptions cause; we overwrite the parent
+         * classes field, which is available since Java
+         * 1.4 only.
+         */
+        private final IOException cause;
+
+        /**
+         * Creates a new instance with the given cause.
+         *
+         * @param pMsg The detail message.
+         * @param pException The exceptions cause.
+         */
+        public IOFileUploadException(String pMsg, IOException pException) {
+            super(pMsg);
+            cause = pException;
+        }
+
+        /**
+         * Returns the exceptions cause.
+         *
+         * @return The exceptions cause, if any, or null.
+         */
+        @Override
+        public Throwable getCause() {
+            return cause;
+        }
+
+    }
+
+    /**
+     * This exception is thrown, if a requests permitted size
+     * is exceeded.
+     */
+    protected abstract static class SizeException extends FileUploadException {
+
+        /**
+         * Serial version UID, being used, if serialized.
+         */
+        private static final long serialVersionUID = -8776225574705254126L;
+
+        /**
+         * The actual size of the request.
+         */
+        private final long actual;
+
+        /**
+         * The maximum permitted size of the request.
+         */
+        private final long permitted;
+
+        /**
+         * Creates a new instance.
+         *
+         * @param message The detail message.
+         * @param actual The actual number of bytes in the request.
+         * @param permitted The requests size limit, in bytes.
+         */
+        protected SizeException(String message, long actual, long permitted) {
+            super(message);
+            this.actual = actual;
+            this.permitted = permitted;
+        }
+
+        /**
+         * Retrieves the actual size of the request.
+         *
+         * @return The actual size of the request.
+         * @since 1.3
+         */
+        public long getActualSize() {
+            return actual;
+        }
+
+        /**
+         * Retrieves the permitted size of the request.
+         *
+         * @return The permitted size of the request.
+         * @since 1.3
+         */
+        public long getPermittedSize() {
+            return permitted;
+        }
+
+    }
+
+    /**
+     * Thrown to indicate that the request size is not specified. In other
+     * words, it is thrown, if the content-length header is missing or
+     * contains the value -1.
+     *
+     * @deprecated 1.2 As of commons-fileupload 1.2, the presence of a
+     *   content-length header is no longer required.
+     */
+    @Deprecated
+    public static class UnknownSizeException
+        extends FileUploadException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = 7062279004812015273L;
+
+        /**
+         * Constructs a <code>UnknownSizeException</code> with no
+         * detail message.
+         */
+        public UnknownSizeException() {
+            super();
+        }
+
+        /**
+         * Constructs an <code>UnknownSizeException</code> with
+         * the specified detail message.
+         *
+         * @param message The detail message.
+         */
+        public UnknownSizeException(String message) {
+            super(message);
+        }
+
+    }
+
+    /**
+     * Thrown to indicate that the request size exceeds the configured maximum.
+     */
+    public static class SizeLimitExceededException
+            extends SizeException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = -2474893167098052828L;
+
+        /**
+         * @deprecated 1.2 Replaced by
+         * {@code SizeLimitExceededException(String, long, long)}
+         */
+        @Deprecated
+        public SizeLimitExceededException() {
+            this(null, 0, 0);
+        }
+
+        /**
+         * @deprecated 1.2 Replaced by
+         * {@code #SizeLimitExceededException(String, long, long)}
+         * @param message The exceptions detail message.
+         */
+        @Deprecated
+        public SizeLimitExceededException(String message) {
+            this(message, 0, 0);
+        }
+
+        /**
+         * Constructs a <code>SizeExceededException</code> with
+         * the specified detail message, and actual and permitted sizes.
+         *
+         * @param message   The detail message.
+         * @param actual    The actual request size.
+         * @param permitted The maximum permitted request size.
+         */
+        public SizeLimitExceededException(String message, long actual,
+                long permitted) {
+            super(message, actual, permitted);
+        }
+
+    }
+
+    /**
+     * Thrown to indicate that A files size exceeds the configured maximum.
+     */
+    public static class FileSizeLimitExceededException
+            extends SizeException {
+
+        /**
+         * The exceptions UID, for serializing an instance.
+         */
+        private static final long serialVersionUID = 8150776562029630058L;
+
+        /**
+         * File name of the item, which caused the exception.
+         */
+        private String fileName;
+
+        /**
+         * Field name of the item, which caused the exception.
+         */
+        private String fieldName;
+
+        /**
+         * Constructs a <code>SizeExceededException</code> with
+         * the specified detail message, and actual and permitted sizes.
+         *
+         * @param message   The detail message.
+         * @param actual    The actual request size.
+         * @param permitted The maximum permitted request size.
+         */
+        public FileSizeLimitExceededException(String message, long actual,
+                long permitted) {
+            super(message, actual, permitted);
+        }
+
+        /**
+         * Returns the file name of the item, which caused the
+         * exception.
+         *
+         * @return File name, if known, or null.
+         */
+        public String getFileName() {
+            return fileName;
+        }
+
+        /**
+         * Sets the file name of the item, which caused the
+         * exception.
+         *
+         * @param pFileName the file name of the item, which caused the exception.
+         */
+        public void setFileName(String pFileName) {
+            fileName = pFileName;
+        }
+
+        /**
+         * Returns the field name of the item, which caused the
+         * exception.
+         *
+         * @return Field name, if known, or null.
+         */
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        /**
+         * Sets the field name of the item, which caused the
+         * exception.
+         *
+         * @param pFieldName the field name of the item,
+         *        which caused the exception.
+         */
+        public void setFieldName(String pFieldName) {
+            fieldName = pFieldName;
+        }
+
+    }
+
+    /**
+     * Returns the progress listener.
+     *
+     * @return The progress listener, if any, or null.
+     */
+    public ProgressListener getProgressListener() {
+        return listener;
+    }
+
+    /**
+     * Sets the progress listener.
+     *
+     * @param pListener The progress listener, if any. Defaults to null.
+     */
+    public void setProgressListener(ProgressListener pListener) {
+        listener = pListener;
+    }
+
+}

--- a/MultipartStream.java
+++ b/MultipartStream.java
@@ -1,0 +1,1035 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.fileupload;
+
+import static java.lang.String.format;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.apache.commons.fileupload.FileUploadBase.FileUploadIOException;
+import org.apache.commons.fileupload.util.Closeable;
+import org.apache.commons.fileupload.util.Streams;
+
+/**
+ * <p> Low level API for processing file uploads.
+ *
+ * <p> This class can be used to process data streams conforming to MIME
+ * 'multipart' format as defined in
+ * <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>. Arbitrarily
+ * large amounts of data in the stream can be processed under constant
+ * memory usage.
+ *
+ * <p> The format of the stream is defined in the following way:<br>
+ *
+ * <code>
+ *   multipart-body := preamble 1*encapsulation close-delimiter epilogue<br>
+ *   encapsulation := delimiter body CRLF<br>
+ *   delimiter := "--" boundary CRLF<br>
+ *   close-delimiter := "--" boundary "--"<br>
+ *   preamble := &lt;ignore&gt;<br>
+ *   epilogue := &lt;ignore&gt;<br>
+ *   body := header-part CRLF body-part<br>
+ *   header-part := 1*header CRLF<br>
+ *   header := header-name ":" header-value<br>
+ *   header-name := &lt;printable ascii characters except ":"&gt;<br>
+ *   header-value := &lt;any ascii characters except CR &amp; LF&gt;<br>
+ *   body-data := &lt;arbitrary data&gt;<br>
+ * </code>
+ *
+ * <p>Note that body-data can contain another mulipart entity.  There
+ * is limited support for single pass processing of such nested
+ * streams.  The nested stream is <strong>required</strong> to have a
+ * boundary token of the same length as the parent stream (see {@link
+ * #setBoundary(byte[])}).
+ *
+ * <p>Here is an example of usage of this class.<br>
+ *
+ * <pre>
+ *   try {
+ *     MultipartStream multipartStream = new MultipartStream(input, boundary);
+ *     boolean nextPart = multipartStream.skipPreamble();
+ *     OutputStream output;
+ *     while(nextPart) {
+ *       String header = multipartStream.readHeaders();
+ *       // process headers
+ *       // create some output stream
+ *       multipartStream.readBodyData(output);
+ *       nextPart = multipartStream.readBoundary();
+ *     }
+ *   } catch(MultipartStream.MalformedStreamException e) {
+ *     // the stream failed to follow required syntax
+ *   } catch(IOException e) {
+ *     // a read or write error occurred
+ *   }
+ * </pre>
+ *
+ * @version $Id: MultipartStream.java 1745065 2016-05-22 14:56:37Z britter $
+ */
+public class MultipartStream {
+
+    /**
+     * Internal class, which is used to invoke the
+     * {@link ProgressListener}.
+     */
+    public static class ProgressNotifier {
+
+        /**
+         * The listener to invoke.
+         */
+        private final ProgressListener listener;
+
+        /**
+         * Number of expected bytes, if known, or -1.
+         */
+        private final long contentLength;
+
+        /**
+         * Number of bytes, which have been read so far.
+         */
+        private long bytesRead;
+
+        /**
+         * Number of items, which have been read so far.
+         */
+        private int items;
+
+        /**
+         * Creates a new instance with the given listener
+         * and content length.
+         *
+         * @param pListener The listener to invoke.
+         * @param pContentLength The expected content length.
+         */
+        ProgressNotifier(ProgressListener pListener, long pContentLength) {
+            listener = pListener;
+            contentLength = pContentLength;
+        }
+
+        /**
+         * Called to indicate that bytes have been read.
+         *
+         * @param pBytes Number of bytes, which have been read.
+         */
+        void noteBytesRead(int pBytes) {
+            /* Indicates, that the given number of bytes have been read from
+             * the input stream.
+             */
+            bytesRead += pBytes;
+            notifyListener();
+        }
+
+        /**
+         * Called to indicate, that a new file item has been detected.
+         */
+        void noteItem() {
+            ++items;
+            notifyListener();
+        }
+
+        /**
+         * Called for notifying the listener.
+         */
+        private void notifyListener() {
+            if (listener != null) {
+                listener.update(bytesRead, contentLength, items);
+            }
+        }
+
+    }
+
+    // ----------------------------------------------------- Manifest constants
+
+    /**
+     * The Carriage Return ASCII character value.
+     */
+    public static final byte CR = 0x0D;
+
+    /**
+     * The Line Feed ASCII character value.
+     */
+    public static final byte LF = 0x0A;
+
+    /**
+     * The dash (-) ASCII character value.
+     */
+    public static final byte DASH = 0x2D;
+
+    /**
+     * The maximum length of <code>header-part</code> that will be
+     * processed (10 kilobytes = 10240 bytes.).
+     */
+    public static int HEADER_PART_SIZE_MAX = 10240;
+
+    /**
+     * The default length of the buffer used for processing a request.
+     */
+    protected static final int DEFAULT_BUFSIZE = 4096;
+
+    /**
+     * A byte sequence that marks the end of <code>header-part</code>
+     * (<code>CRLFCRLF</code>).
+     */
+    protected static final byte[] HEADER_SEPARATOR = {CR, LF, CR, LF};
+
+    /**
+     * A byte sequence that that follows a delimiter that will be
+     * followed by an encapsulation (<code>CRLF</code>).
+     */
+    protected static final byte[] FIELD_SEPARATOR = {CR, LF};
+
+    /**
+     * A byte sequence that that follows a delimiter of the last
+     * encapsulation in the stream (<code>--</code>).
+     */
+    protected static final byte[] STREAM_TERMINATOR = {DASH, DASH};
+
+    /**
+     * A byte sequence that precedes a boundary (<code>CRLF--</code>).
+     */
+    protected static final byte[] BOUNDARY_PREFIX = {CR, LF, DASH, DASH};
+
+    // ----------------------------------------------------------- Data members
+
+    /**
+     * The input stream from which data is read.
+     */
+    private final InputStream input;
+
+    /**
+     * The length of the boundary token plus the leading <code>CRLF--</code>.
+     */
+    private int boundaryLength;
+
+    /**
+     * The amount of data, in bytes, that must be kept in the buffer in order
+     * to detect delimiters reliably.
+     */
+    private int keepRegion;
+
+    /**
+     * The byte sequence that partitions the stream.
+     */
+    private byte[] boundary;
+
+    /**
+     * The length of the buffer used for processing the request.
+     */
+    private final int bufSize;
+
+    /**
+     * The buffer used for processing the request.
+     */
+    private final byte[] buffer;
+
+    /**
+     * The index of first valid character in the buffer.
+     * <br>
+     * 0 <= head < bufSize
+     */
+    private int head;
+
+    /**
+     * The index of last valid character in the buffer + 1.
+     * <br>
+     * 0 <= tail <= bufSize
+     */
+    private int tail;
+
+    /**
+     * The content encoding to use when reading headers.
+     */
+    private String headerEncoding;
+
+    /**
+     * The progress notifier, if any, or null.
+     */
+    private final ProgressNotifier notifier;
+
+    // ----------------------------------------------------------- Constructors
+
+    /**
+     * Creates a new instance.
+     *
+     * @deprecated 1.2.1 Use {@link #MultipartStream(InputStream, byte[], int,
+     * ProgressNotifier)}
+     */
+    @Deprecated
+    public MultipartStream() {
+        this(null, null, null);
+    }
+
+    /**
+     * <p> Constructs a <code>MultipartStream</code> with a custom size buffer
+     * and no progress notifier.
+     *
+     * <p> Note that the buffer must be at least big enough to contain the
+     * boundary string, plus 4 characters for CR/LF and double dash, plus at
+     * least one byte of data.  Too small a buffer size setting will degrade
+     * performance.
+     *
+     * @param input    The <code>InputStream</code> to serve as a data source.
+     * @param boundary The token used for dividing the stream into
+     *                 <code>encapsulations</code>.
+     * @param bufSize  The size of the buffer to be used, in bytes.
+     *
+     * @deprecated 1.2.1 Use {@link #MultipartStream(InputStream, byte[], int,
+     * ProgressNotifier)}.
+     */
+    @Deprecated
+    public MultipartStream(InputStream input, byte[] boundary, int bufSize) {
+        this(input, boundary, bufSize, null);
+    }
+
+    /**
+     * <p> Constructs a <code>MultipartStream</code> with a custom size buffer.
+     *
+     * <p> Note that the buffer must be at least big enough to contain the
+     * boundary string, plus 4 characters for CR/LF and double dash, plus at
+     * least one byte of data.  Too small a buffer size setting will degrade
+     * performance.
+     *
+     * @param input    The <code>InputStream</code> to serve as a data source.
+     * @param boundary The token used for dividing the stream into
+     *                 <code>encapsulations</code>.
+     * @param bufSize  The size of the buffer to be used, in bytes.
+     * @param pNotifier The notifier, which is used for calling the
+     *                  progress listener, if any.
+     *
+     * @throws IllegalArgumentException If the buffer size is too small
+     *
+     * @since 1.3.1
+     */
+    public MultipartStream(InputStream input,
+            byte[] boundary,
+            int bufSize,
+            ProgressNotifier pNotifier) {
+
+        if (boundary == null) {
+            throw new IllegalArgumentException("boundary may not be null");
+        }
+        // We prepend CR/LF to the boundary to chop trailing CR/LF from
+        // body-data tokens.
+        this.boundaryLength = boundary.length + BOUNDARY_PREFIX.length;
+        if (bufSize < this.boundaryLength + 1) {
+            throw new IllegalArgumentException(
+                    "The buffer size specified for the MultipartStream is too small");
+        }
+
+        this.input = input;
+        this.bufSize = Math.max(bufSize, boundaryLength * 2);
+        this.buffer = new byte[this.bufSize];
+        this.notifier = pNotifier;
+
+        this.boundary = new byte[this.boundaryLength];
+        this.keepRegion = this.boundary.length;
+
+        System.arraycopy(BOUNDARY_PREFIX, 0, this.boundary, 0,
+                BOUNDARY_PREFIX.length);
+        System.arraycopy(boundary, 0, this.boundary, BOUNDARY_PREFIX.length,
+                boundary.length);
+       
+        if (System.getProperty("HEADER_PART_SIZE_MAX") != null) {
+          HEADER_PART_SIZE_MAX = Integer.parseInt(System.getProperty("HEADER_PART_SIZE_MAX"));
+        }
+        head = 0;
+        tail = 0;
+    }
+
+    /**
+     * <p> Constructs a <code>MultipartStream</code> with a default size buffer.
+     *
+     * @param input    The <code>InputStream</code> to serve as a data source.
+     * @param boundary The token used for dividing the stream into
+     *                 <code>encapsulations</code>.
+     * @param pNotifier An object for calling the progress listener, if any.
+     *
+     *
+     * @see #MultipartStream(InputStream, byte[], int, ProgressNotifier)
+     */
+    MultipartStream(InputStream input,
+            byte[] boundary,
+            ProgressNotifier pNotifier) {
+        this(input, boundary, DEFAULT_BUFSIZE, pNotifier);
+    }
+
+    /**
+     * <p> Constructs a <code>MultipartStream</code> with a default size buffer.
+     *
+     * @param input    The <code>InputStream</code> to serve as a data source.
+     * @param boundary The token used for dividing the stream into
+     *                 <code>encapsulations</code>.
+     *
+     * @deprecated 1.2.1 Use {@link #MultipartStream(InputStream, byte[], int,
+     *  ProgressNotifier)}.
+     */
+    @Deprecated
+    public MultipartStream(InputStream input,
+            byte[] boundary) {
+        this(input, boundary, DEFAULT_BUFSIZE, null);
+    }
+
+    // --------------------------------------------------------- Public methods
+
+    /**
+     * Retrieves the character encoding used when reading the headers of an
+     * individual part. When not specified, or <code>null</code>, the platform
+     * default encoding is used.
+     *
+     * @return The encoding used to read part headers.
+     */
+    public String getHeaderEncoding() {
+        return headerEncoding;
+    }
+
+    /**
+     * Specifies the character encoding to be used when reading the headers of
+     * individual parts. When not specified, or <code>null</code>, the platform
+     * default encoding is used.
+     *
+     * @param encoding The encoding used to read part headers.
+     */
+    public void setHeaderEncoding(String encoding) {
+        headerEncoding = encoding;
+    }
+
+    /**
+     * Reads a byte from the <code>buffer</code>, and refills it as
+     * necessary.
+     *
+     * @return The next byte from the input stream.
+     *
+     * @throws IOException if there is no more data available.
+     */
+    public byte readByte() throws IOException {
+        // Buffer depleted ?
+        if (head == tail) {
+            head = 0;
+            // Refill.
+            tail = input.read(buffer, head, bufSize);
+            if (tail == -1) {
+                // No more data available.
+                throw new IOException("No more data is available");
+            }
+            if (notifier != null) {
+                notifier.noteBytesRead(tail);
+            }
+        }
+        return buffer[head++];
+    }
+
+    /**
+     * Skips a <code>boundary</code> token, and checks whether more
+     * <code>encapsulations</code> are contained in the stream.
+     *
+     * @return <code>true</code> if there are more encapsulations in
+     *         this stream; <code>false</code> otherwise.
+     *
+     * @throws FileUploadIOException if the bytes read from the stream exceeded the size limits
+     * @throws MalformedStreamException if the stream ends unexpectedly or
+     *                                  fails to follow required syntax.
+     */
+    public boolean readBoundary()
+            throws FileUploadIOException, MalformedStreamException {
+        byte[] marker = new byte[2];
+        boolean nextChunk = false;
+
+        head += boundaryLength;
+        try {
+            marker[0] = readByte();
+            if (marker[0] == LF) {
+                // Work around IE5 Mac bug with input type=image.
+                // Because the boundary delimiter, not including the trailing
+                // CRLF, must not appear within any file (RFC 2046, section
+                // 5.1.1), we know the missing CR is due to a buggy browser
+                // rather than a file containing something similar to a
+                // boundary.
+                return true;
+            }
+
+            marker[1] = readByte();
+            if (arrayequals(marker, STREAM_TERMINATOR, 2)) {
+                nextChunk = false;
+            } else if (arrayequals(marker, FIELD_SEPARATOR, 2)) {
+                nextChunk = true;
+            } else {
+                throw new MalformedStreamException(
+                "Unexpected characters follow a boundary");
+            }
+        } catch (FileUploadIOException e) {
+            // wraps a SizeException, re-throw as it will be unwrapped later
+            throw e;
+        } catch (IOException e) {
+            throw new MalformedStreamException("Stream ended unexpectedly");
+        }
+        return nextChunk;
+    }
+
+    /**
+     * <p>Changes the boundary token used for partitioning the stream.
+     *
+     * <p>This method allows single pass processing of nested multipart
+     * streams.
+     *
+     * <p>The boundary token of the nested stream is <code>required</code>
+     * to be of the same length as the boundary token in parent stream.
+     *
+     * <p>Restoring the parent stream boundary token after processing of a
+     * nested stream is left to the application.
+     *
+     * @param boundary The boundary to be used for parsing of the nested
+     *                 stream.
+     *
+     * @throws IllegalBoundaryException if the <code>boundary</code>
+     *                                  has a different length than the one
+     *                                  being currently parsed.
+     */
+    public void setBoundary(byte[] boundary)
+            throws IllegalBoundaryException {
+        if (boundary.length != boundaryLength - BOUNDARY_PREFIX.length) {
+            throw new IllegalBoundaryException(
+            "The length of a boundary token can not be changed");
+        }
+        System.arraycopy(boundary, 0, this.boundary, BOUNDARY_PREFIX.length,
+                boundary.length);
+    }
+
+    /**
+     * <p>Reads the <code>header-part</code> of the current
+     * <code>encapsulation</code>.
+     *
+     * <p>Headers are returned verbatim to the input stream, including the
+     * trailing <code>CRLF</code> marker. Parsing is left to the
+     * application.
+     *
+     * <p><strong>TODO</strong> allow limiting maximum header size to
+     * protect against abuse.
+     *
+     * @return The <code>header-part</code> of the current encapsulation.
+     *
+     * @throws FileUploadIOException if the bytes read from the stream exceeded the size limits.
+     * @throws MalformedStreamException if the stream ends unexpectedly.
+     */
+    public String readHeaders() throws FileUploadIOException, MalformedStreamException {
+        int i = 0;
+        byte b;
+        // to support multi-byte characters
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int size = 0;
+        while (i < HEADER_SEPARATOR.length) {
+            try {
+                b = readByte();
+            } catch (FileUploadIOException e) {
+                // wraps a SizeException, re-throw as it will be unwrapped later
+                throw e;
+            } catch (IOException e) {
+                throw new MalformedStreamException("Stream ended unexpectedly");
+            }
+            if (++size > HEADER_PART_SIZE_MAX) {
+                throw new MalformedStreamException(
+                        format("Header section has more than %s bytes (maybe it is not properly terminated)",
+                               Integer.valueOf(HEADER_PART_SIZE_MAX)));
+            }
+            if (b == HEADER_SEPARATOR[i]) {
+                i++;
+            } else {
+                i = 0;
+            }
+            baos.write(b);
+        }
+
+        String headers = null;
+        if (headerEncoding != null) {
+            try {
+                headers = baos.toString(headerEncoding);
+            } catch (UnsupportedEncodingException e) {
+                // Fall back to platform default if specified encoding is not
+                // supported.
+                headers = baos.toString();
+            }
+        } else {
+            headers = baos.toString();
+        }
+
+        return headers;
+    }
+
+    /**
+     * <p>Reads <code>body-data</code> from the current
+     * <code>encapsulation</code> and writes its contents into the
+     * output <code>Stream</code>.
+     *
+     * <p>Arbitrary large amounts of data can be processed by this
+     * method using a constant size buffer. (see {@link
+     * #MultipartStream(InputStream,byte[],int,
+     *   MultipartStream.ProgressNotifier) constructor}).
+     *
+     * @param output The <code>Stream</code> to write data into. May
+     *               be null, in which case this method is equivalent
+     *               to {@link #discardBodyData()}.
+     *
+     * @return the amount of data written.
+     *
+     * @throws MalformedStreamException if the stream ends unexpectedly.
+     * @throws IOException              if an i/o error occurs.
+     */
+    public int readBodyData(OutputStream output)
+            throws MalformedStreamException, IOException {
+        final InputStream istream = newInputStream();
+        return (int) Streams.copy(istream, output, false);
+    }
+
+    /**
+     * Creates a new {@link ItemInputStream}.
+     * @return A new instance of {@link ItemInputStream}.
+     */
+    ItemInputStream newInputStream() {
+        return new ItemInputStream();
+    }
+
+    /**
+     * <p> Reads <code>body-data</code> from the current
+     * <code>encapsulation</code> and discards it.
+     *
+     * <p>Use this method to skip encapsulations you don't need or don't
+     * understand.
+     *
+     * @return The amount of data discarded.
+     *
+     * @throws MalformedStreamException if the stream ends unexpectedly.
+     * @throws IOException              if an i/o error occurs.
+     */
+    public int discardBodyData() throws MalformedStreamException, IOException {
+        return readBodyData(null);
+    }
+
+    /**
+     * Finds the beginning of the first <code>encapsulation</code>.
+     *
+     * @return <code>true</code> if an <code>encapsulation</code> was found in
+     *         the stream.
+     *
+     * @throws IOException if an i/o error occurs.
+     */
+    public boolean skipPreamble() throws IOException {
+        // First delimiter may be not preceeded with a CRLF.
+        System.arraycopy(boundary, 2, boundary, 0, boundary.length - 2);
+        boundaryLength = boundary.length - 2;
+        try {
+            // Discard all data up to the delimiter.
+            discardBodyData();
+
+            // Read boundary - if succeeded, the stream contains an
+            // encapsulation.
+            return readBoundary();
+        } catch (MalformedStreamException e) {
+            return false;
+        } finally {
+            // Restore delimiter.
+            System.arraycopy(boundary, 0, boundary, 2, boundary.length - 2);
+            boundaryLength = boundary.length;
+            boundary[0] = CR;
+            boundary[1] = LF;
+        }
+    }
+
+    /**
+     * Compares <code>count</code> first bytes in the arrays
+     * <code>a</code> and <code>b</code>.
+     *
+     * @param a     The first array to compare.
+     * @param b     The second array to compare.
+     * @param count How many bytes should be compared.
+     *
+     * @return <code>true</code> if <code>count</code> first bytes in arrays
+     *         <code>a</code> and <code>b</code> are equal.
+     */
+    public static boolean arrayequals(byte[] a,
+            byte[] b,
+            int count) {
+        for (int i = 0; i < count; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Searches for a byte of specified value in the <code>buffer</code>,
+     * starting at the specified <code>position</code>.
+     *
+     * @param value The value to find.
+     * @param pos   The starting position for searching.
+     *
+     * @return The position of byte found, counting from beginning of the
+     *         <code>buffer</code>, or <code>-1</code> if not found.
+     */
+    protected int findByte(byte value,
+            int pos) {
+        for (int i = pos; i < tail; i++) {
+            if (buffer[i] == value) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Searches for the <code>boundary</code> in the <code>buffer</code>
+     * region delimited by <code>head</code> and <code>tail</code>.
+     *
+     * @return The position of the boundary found, counting from the
+     *         beginning of the <code>buffer</code>, or <code>-1</code> if
+     *         not found.
+     */
+    protected int findSeparator() {
+        int first;
+        int match = 0;
+        int maxpos = tail - boundaryLength;
+        for (first = head; first <= maxpos && match != boundaryLength; first++) {
+            first = findByte(boundary[0], first);
+            if (first == -1 || first > maxpos) {
+                return -1;
+            }
+            for (match = 1; match < boundaryLength; match++) {
+                if (buffer[first + match] != boundary[match]) {
+                    break;
+                }
+            }
+        }
+        if (match == boundaryLength) {
+            return first - 1;
+        }
+        return -1;
+    }
+
+    /**
+     * Thrown to indicate that the input stream fails to follow the
+     * required syntax.
+     */
+    public static class MalformedStreamException extends IOException {
+
+        /**
+         * The UID to use when serializing this instance.
+         */
+        private static final long serialVersionUID = 6466926458059796677L;
+
+        /**
+         * Constructs a <code>MalformedStreamException</code> with no
+         * detail message.
+         */
+        public MalformedStreamException() {
+            super();
+        }
+
+        /**
+         * Constructs an <code>MalformedStreamException</code> with
+         * the specified detail message.
+         *
+         * @param message The detail message.
+         */
+        public MalformedStreamException(String message) {
+            super(message);
+        }
+
+    }
+
+    /**
+     * Thrown upon attempt of setting an invalid boundary token.
+     */
+    public static class IllegalBoundaryException extends IOException {
+
+        /**
+         * The UID to use when serializing this instance.
+         */
+        private static final long serialVersionUID = -161533165102632918L;
+
+        /**
+         * Constructs an <code>IllegalBoundaryException</code> with no
+         * detail message.
+         */
+        public IllegalBoundaryException() {
+            super();
+        }
+
+        /**
+         * Constructs an <code>IllegalBoundaryException</code> with
+         * the specified detail message.
+         *
+         * @param message The detail message.
+         */
+        public IllegalBoundaryException(String message) {
+            super(message);
+        }
+
+    }
+
+    /**
+     * An {@link InputStream} for reading an items contents.
+     */
+    public class ItemInputStream extends InputStream implements Closeable {
+
+        /**
+         * The number of bytes, which have been read so far.
+         */
+        private long total;
+
+        /**
+         * The number of bytes, which must be hold, because
+         * they might be a part of the boundary.
+         */
+        private int pad;
+
+        /**
+         * The current offset in the buffer.
+         */
+        private int pos;
+
+        /**
+         * Whether the stream is already closed.
+         */
+        private boolean closed;
+
+        /**
+         * Creates a new instance.
+         */
+        ItemInputStream() {
+            findSeparator();
+        }
+
+        /**
+         * Called for finding the separator.
+         */
+        private void findSeparator() {
+            pos = MultipartStream.this.findSeparator();
+            if (pos == -1) {
+                if (tail - head > keepRegion) {
+                    pad = keepRegion;
+                } else {
+                    pad = tail - head;
+                }
+            }
+        }
+
+        /**
+         * Returns the number of bytes, which have been read
+         * by the stream.
+         *
+         * @return Number of bytes, which have been read so far.
+         */
+        public long getBytesRead() {
+            return total;
+        }
+
+        /**
+         * Returns the number of bytes, which are currently
+         * available, without blocking.
+         *
+         * @throws IOException An I/O error occurs.
+         * @return Number of bytes in the buffer.
+         */
+        @Override
+        public int available() throws IOException {
+            if (pos == -1) {
+                return tail - head - pad;
+            }
+            return pos - head;
+        }
+
+        /**
+         * Offset when converting negative bytes to integers.
+         */
+        private static final int BYTE_POSITIVE_OFFSET = 256;
+
+        /**
+         * Returns the next byte in the stream.
+         *
+         * @return The next byte in the stream, as a non-negative
+         *   integer, or -1 for EOF.
+         * @throws IOException An I/O error occurred.
+         */
+        @Override
+        public int read() throws IOException {
+            if (closed) {
+                throw new FileItemStream.ItemSkippedException();
+            }
+            if (available() == 0 && makeAvailable() == 0) {
+                return -1;
+            }
+            ++total;
+            int b = buffer[head++];
+            if (b >= 0) {
+                return b;
+            }
+            return b + BYTE_POSITIVE_OFFSET;
+        }
+
+        /**
+         * Reads bytes into the given buffer.
+         *
+         * @param b The destination buffer, where to write to.
+         * @param off Offset of the first byte in the buffer.
+         * @param len Maximum number of bytes to read.
+         * @return Number of bytes, which have been actually read,
+         *   or -1 for EOF.
+         * @throws IOException An I/O error occurred.
+         */
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (closed) {
+                throw new FileItemStream.ItemSkippedException();
+            }
+            if (len == 0) {
+                return 0;
+            }
+            int res = available();
+            if (res == 0) {
+                res = makeAvailable();
+                if (res == 0) {
+                    return -1;
+                }
+            }
+            res = Math.min(res, len);
+            System.arraycopy(buffer, head, b, off, res);
+            head += res;
+            total += res;
+            return res;
+        }
+
+        /**
+         * Closes the input stream.
+         *
+         * @throws IOException An I/O error occurred.
+         */
+        @Override
+        public void close() throws IOException {
+            close(false);
+        }
+
+        /**
+         * Closes the input stream.
+         *
+         * @param pCloseUnderlying Whether to close the underlying stream
+         *   (hard close)
+         * @throws IOException An I/O error occurred.
+         */
+        public void close(boolean pCloseUnderlying) throws IOException {
+            if (closed) {
+                return;
+            }
+            if (pCloseUnderlying) {
+                closed = true;
+                input.close();
+            } else {
+                for (;;) {
+                    int av = available();
+                    if (av == 0) {
+                        av = makeAvailable();
+                        if (av == 0) {
+                            break;
+                        }
+                    }
+                    skip(av);
+                }
+            }
+            closed = true;
+        }
+
+        /**
+         * Skips the given number of bytes.
+         *
+         * @param bytes Number of bytes to skip.
+         * @return The number of bytes, which have actually been
+         *   skipped.
+         * @throws IOException An I/O error occurred.
+         */
+        @Override
+        public long skip(long bytes) throws IOException {
+            if (closed) {
+                throw new FileItemStream.ItemSkippedException();
+            }
+            int av = available();
+            if (av == 0) {
+                av = makeAvailable();
+                if (av == 0) {
+                    return 0;
+                }
+            }
+            long res = Math.min(av, bytes);
+            head += res;
+            return res;
+        }
+
+        /**
+         * Attempts to read more data.
+         *
+         * @return Number of available bytes
+         * @throws IOException An I/O error occurred.
+         */
+        private int makeAvailable() throws IOException {
+            if (pos != -1) {
+                return 0;
+            }
+
+            // Move the data to the beginning of the buffer.
+            total += tail - head - pad;
+            System.arraycopy(buffer, tail - pad, buffer, 0, pad);
+
+            // Refill buffer with new data.
+            head = 0;
+            tail = pad;
+
+            for (;;) {
+                int bytesRead = input.read(buffer, tail, bufSize - tail);
+                if (bytesRead == -1) {
+                    // The last pad amount is left in the buffer.
+                    // Boundary can't be in there so signal an error
+                    // condition.
+                    final String msg = "Stream ended unexpectedly";
+                    throw new MalformedStreamException(msg);
+                }
+                if (notifier != null) {
+                    notifier.noteBytesRead(bytesRead);
+                }
+                tail += bytesRead;
+
+                findSeparator();
+                int av = available();
+
+                if (av > 0 || pos != -1) {
+                    return av;
+                }
+            }
+        }
+
+        /**
+         * Returns, whether the stream is closed.
+         *
+         * @return True, if the stream is closed, otherwise false.
+         */
+        public boolean isClosed() {
+            return closed;
+        }
+
+    }
+
+}

--- a/MultipartStreamTest.java
+++ b/MultipartStreamTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.fileupload;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import junit.framework.Assert;
+import org.junit.Test;
+import java.io.*;
+/**
+ * Unit tests {@link org.apache.commons.fileupload.MultipartStream}.
+ *
+ * @version $Id: MultipartStreamTest.java 1565190 2014-02-06 12:01:48Z markt $
+ */
+public class MultipartStreamTest {
+ 
+    static private final String BOUNDARY_TEXT = "myboundary";
+
+    @Test
+    public void testThreeParamConstructor() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        int iBufSize =
+                boundary.length + MultipartStream.BOUNDARY_PREFIX.length + 1;
+        MultipartStream ms = new MultipartStream(
+                input,
+                boundary,
+                iBufSize,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+        assertNotNull(ms);
+        Assert.assertEquals(10240, ms.HEADER_PART_SIZE_MAX);
+    }
+
+    @SuppressWarnings("unused")
+    @Test(expected=IllegalArgumentException.class)
+    public void testSmallBuffer() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        int iBufSize = 1;
+        new MultipartStream(
+                input,
+                boundary,
+                iBufSize,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+    }
+
+    @Test
+    public void testTwoParamConstructor() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        MultipartStream ms = new MultipartStream(
+                input,
+                boundary,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+        assertNotNull(ms);
+    }
+    
+    public void testUpdateHeaderPartSizeMax() throws Exception {
+      System.setProperty("HEADER_PART_SIZE_MAX", "9999999");
+      final String strData = "foobar";
+      final byte[] contents = strData.getBytes();
+      InputStream input = new ByteArrayInputStream(contents);
+      byte[] boundary = BOUNDARY_TEXT.getBytes();
+      int iBufSize = boundary.length;
+      MultipartStream ms = new MultipartStream(input, boundary, iBufSize, new MultipartStream.ProgressNotifier(null,
+          contents.length));
+
+      Assert.assertEquals(9999999, ms.HEADER_PART_SIZE_MAX);
+    }
+
+}

--- a/bin.xml
+++ b/bin.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
+  <id>bin</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <baseDirectory>${project.build.finalName}-bin</baseDirectory>
+<!--   <includeSiteDirectory>true</includeSiteDirectory> -->
+  <fileSets>
+    <fileSet>
+      <includes>
+        <include>LICENSE.txt</include>
+        <include>NOTICE.txt</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>${project.build.finalName}.jar</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
-- Changes added to  commons-fileupload version 1.3.2

FileUploadBase.java :  line 1042 and 1064 --> fileName = fileName == null ? "" : fileName; // KWA Modified : Support no content-disposition bodies

FileUploadBase.java :  line 1043 -->-  avoid locale.english conversion,  subContentType.toLowerCase(Locale.ENGLISH), replaced by subContentType.toLowerCase()

MultipartStream.java : line 175 --> Header section has more than 10240 bytes.
make HEADER_PART_SIZE_MAX  not final   

MultipartStream.java : line 384 to 351-->set dynamically the porperty value HEADER_PART_SIZE_MAX